### PR TITLE
fix compilation-error of pinv test

### DIFF
--- a/source/lubeck.d
+++ b/source/lubeck.d
@@ -669,7 +669,7 @@ Slice!(Contiguous, [2], BlasType!Iterator*)
     }
     auto s = svd.sigma[0 .. $ - svd.sigma.find!(a => !(a >= tolerance))[0]];
     s.each!"a = 1 / a";
-    svd.vt.pack!1.map!"a".zip(s).each!"a.a[] *= a.b";
+    svd.vt[0 .. s.length].pack!1.map!"a".zip(s).each!"a.a[] *= a.b";
     auto v = svd.vt[0 .. s.length].universal.transposed;
     auto ut = svd.u.universal.transposed[0 .. s.length];
     return v.mtimes(ut);


### PR DESCRIPTION
Without shaping appropriately, it fails as
`zip: all slices must have the same lengths`
in my environment LDC1.4.0
``` json
{
	"fileVersion": 1,
	"versions": {
		"cblas": "2.0.0",
		"lapack": "0.0.2",
		"mir-algorithm": "0.6.21",
		"mir-blas": "0.0.2",
		"mir-lapack": "0.0.3",
		"mir-random": "0.2.8"
	}
}
```
Does zip's behaviour changed?