### PR TITLE
Fix CI failure due to python environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 
 language: d
@@ -19,8 +19,8 @@ addons:
       - pkg-config
 
 install:
-  - pyenv global system 3.6
-  - pip3 install 'meson>=0.45'
+  - sudo apt-get install python3-pip python3-setuptools
+  - pip3 install 'meson>=0.48.2'
   - mkdir .ntmp
   - curl -L https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip -o .ntmp/ninja-linux.zip
   - unzip .ntmp/ninja-linux.zip -d .ntmp


### PR DESCRIPTION
After Travis move to container-based infrestructure to VM-based, the default python 3 version is now 3.4.3 which isn't supported by Meson. The xenial ubuntu includes by default python 3.5 which is good for Meson.
The fix also prefer updating the system package rather tan using pyenv (the latter was leading to other possible errors).