### PR TITLE
test: inverse of a matrix does not contain "negative zero"

### DIFF
--- a/source/kaleidic/lubeck.d
+++ b/source/kaleidic/lubeck.d
@@ -334,6 +334,16 @@ unittest
     assert(equal!((a, b) => a.approxEqual(b, 1e-10L, 1e-10L))(a.as!cdouble.inv.as!double, ans));
 }
 
+unittest
+{
+    import mir.algorithm.iteration: all;
+
+    auto identity = slice!double([4, 4], 0);
+	identity.diagonal[] = 1;
+
+    assert(identity.inv.all!"a > 0");
+}
+
 ///
 unittest
 {


### PR DESCRIPTION
I noticed that when you invert a matrix you can end up with negative zero.