### PR TITLE
Add additional overloads for mtimes (with handling for self-adjoint)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ lubeck-test-unittest
 build
 builddir
 subprojects/*/
+
+*.pdb

--- a/dub.sdl
+++ b/dub.sdl
@@ -7,96 +7,101 @@ license "BSL-1.0"
 dependency "mir-lapack" version="~>1.2.9"
 
 configuration "library" {
-	targetType "library"
-	# default or user specified mir-lapack sub-configuration is used
+    targetType "library"
+    # default or user specified mir-lapack sub-configuration is used
 }
 
 configuration "unittest" {
-	dependency "mir-random" version=">=2.2.5"
+    dependency "mir-random" version=">=2.2.5"
 }
 
 configuration "openblas" {
-	subConfiguration "mir-lapack" "openblas"
+    subConfiguration "mir-lapack" "openblas"
 }
 
 configuration "threelib" {
-	subConfiguration "mir-lapack" "threelib"
+    subConfiguration "mir-lapack" "threelib"
 }
 
 configuration "cblas" {
-	subConfiguration "mir-lapack" "cblas"
+    subConfiguration "mir-lapack" "cblas"
 }
 
 configuration "blas" {
-	subConfiguration "mir-lapack" "blas"
+    subConfiguration "mir-lapack" "blas"
 }
 
 configuration "lapack" {
-	subConfiguration "mir-lapack" "lapack"
+    subConfiguration "mir-lapack" "lapack"
 }
 
 configuration "mkl-sequential" {
-	subConfiguration "mir-lapack" "mkl-sequential"
+    subConfiguration "mir-lapack" "mkl-sequential"
 }
 
 configuration "mkl-sequential-ilp" {
-	subConfiguration "mir-lapack" "mkl-sequential-ilp"
+    subConfiguration "mir-lapack" "mkl-sequential-ilp"
 }
 
 configuration "mkl-tbb-thread" {
-	subConfiguration "mir-lapack" "mkl-tbb-thread"
+    subConfiguration "mir-lapack" "mkl-tbb-thread"
 }
 
 configuration "mkl-tbb-thread-ilp" {
-	subConfiguration "mir-lapack" "mkl-tbb-thread-ilp"
+    subConfiguration "mir-lapack" "mkl-tbb-thread-ilp"
 }
 
 configuration "mkl-sequential-dll" {
-	subConfiguration "mir-lapack" "mkl-sequential-dll"
+    subConfiguration "mir-lapack" "mkl-sequential-dll"
 }
 
 configuration "mkl-sequential-ilp-dll" {
-	subConfiguration "mir-lapack" "mkl-sequential-ilp-dll"
+    subConfiguration "mir-lapack" "mkl-sequential-ilp-dll"
 }
 
 configuration "mkl-tbb-thread-dll" {
-	subConfiguration "mir-lapack" "mkl-tbb-thread-dll"
+    subConfiguration "mir-lapack" "mkl-tbb-thread-dll"
 }
 
 configuration "mkl-tbb-thread-ilp-dll" {
-	subConfiguration "mir-lapack" "mkl-tbb-thread-ilp-dll"
+    subConfiguration "mir-lapack" "mkl-tbb-thread-ilp-dll"
 }
 
 configuration "zerolib" {
-	subConfiguration "mir-lapack" "zerolib"
+    subConfiguration "mir-lapack" "zerolib"
 }
 
 configuration "unittest-openblas" {
-	dependency "mir-random" version=">=2.2.5"
-	subConfiguration "mir-lapack" "openblas"
+    dependency "mir-random" version=">=2.2.5"
+    subConfiguration "mir-lapack" "openblas"
 }
 
 configuration "unittest-threelib" {
-	dependency "mir-random" version=">=2.2.5"
-	subConfiguration "mir-lapack" "threelib"
+    dependency "mir-random" version=">=2.2.5"
+    subConfiguration "mir-lapack" "threelib"
 }
 
 configuration "unittest-cblas" {
-	dependency "mir-random" version=">=2.2.5"
-	subConfiguration "mir-lapack" "cblas"
+    dependency "mir-random" version=">=2.2.5"
+    subConfiguration "mir-lapack" "cblas"
 }
 
 configuration "unittest-blas" {
-	dependency "mir-random" version=">=2.2.5"
-	subConfiguration "mir-lapack" "blas"
+    dependency "mir-random" version=">=2.2.5"
+    subConfiguration "mir-lapack" "blas"
 }
 
 configuration "unittest-lapack" {
-	dependency "mir-random" version=">=2.2.5"
-	subConfiguration "mir-lapack" "lapack"
+    dependency "mir-random" version=">=2.2.5"
+    subConfiguration "mir-lapack" "lapack"
 }
 
 configuration "unittest-mkl-sequential" {
-	dependency "mir-random" version=">=2.2.5"
-	subConfiguration "mir-lapack" "mkl-sequential"
+    dependency "mir-random" version=">=2.2.5"
+    subConfiguration "mir-lapack" "mkl-sequential"
+}
+
+buildType "unittest-cov" {
+    buildOptions "unittests" "coverage" "debugMode" "debugInfo"
+    dependency "mir-random" version=">=2.2.5"
 }

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -330,12 +330,6 @@ template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
     in
     {
         assert(a.length!0 == b.length);
-        static if (assumedMatrix == AssumedMatrix.selfAdjoint ||
-                   assumedMatrix == AssumedMatrix.selfAdjointRight) {
-            assert(a.length!0 == a.length!1);
-            static if (isFloatingPoint!T)
-                assert(isSymmetric(a));
-        }
     }
     out (c)
     {
@@ -343,16 +337,7 @@ template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
     }
     do
     {
-        static if (assumedMatrix == AssumedMatrix.general) {
-            auto c = mininitRcslice!T(a.length!1);
-            gemv(cast(T)1, a.transposed, b, cast(T)0, c.lightScope);
-            return c;
-        } else static if (assumedMatrix == AssumedMatrix.selfAdjoint ||
-                          assumedMatrix == AssumedMatrix.selfAdjointRight) {
-            return .mtimes!assumedMatrix(a, b);
-        } else {
-            static assert(0, "Not implemented");
-        }
+        return .mtimes!assumedMatrix(a.universal.transposed, b);
     }
 
     /// ditto

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -848,7 +848,6 @@ unittest
 {
     import mir.algorithm.iteration: equal;
     import mir.ndslice.allocation: mininitRcslice;
-    import mir.ndslice.topology: universal;
 
     static immutable a = [[3.0, 5, 2], [5.0, 2, 3], [2.0, 3, 1]];
     static immutable b = [[2.0, 3], [4.0, 3], [0.0, -5]];
@@ -870,9 +869,13 @@ unittest
 
     auto YTX = YT.mtimesSymmetric!"Right"(X);
     assert(YTX.equal(result.transposed));
-    // may need to allocate transposed LHS
+    // May need to allocate transposed LHS
     auto YtransX = Y.transposed.rcslice.mtimesSymmetric!"Right"(X);
     assert(YtransX.equal(result.transposed));
+    // Can avoid by transposing problem and result
+    auto YtransX_v2 = X.mtimesSymmetric(Y).transposed;
+    assert(YtransX_v2.equal(result.transposed));
+    
 }
 
 /// Symmetric Matrix, specialization for MxN times Nx1

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -71,14 +71,6 @@ unittest
         [0]]);
 }
 
-///
-enum AssumedMatrix
-{
-    general,
-    selfAdjoint,
-    selfAdjointRight
-}
-
 /++
 Matrix multiplication. Allocates result to using Mir refcounted arrays.
 
@@ -92,305 +84,242 @@ of as a column vector.
 slice. The result is a one-dimensional slice. In this case, `b` can be thought
 of as a row vector.
 
-The template parameter `assumedMatrix` controls the BLAS algorithms that are
-used to perform the matrix multiplication.
-- AssumedMatrix.general (default): Assumes matrix `a` is a general matrix and
-uses `gemm` for matrix-matrix operations and `gemv` for matrix-vector operations.
-- AssumedMatrix.selfAdjoint: Assumes matrix `a` is a self-adjoint matrix
-(symmetric in the real case, hermetian in the complex case, but not currently
-implemented) and uses `symm`/`hemm` for matrix-matrix operations and
-`symv`/`hemv` for matrix-vector operations.
-- AssumedMatrix.selfAdjointRight: Assumes matrix `b` is a self-adjoint matrix
-(symmetric in the real case, hermetian in the complex case, but not currently
-implemented). For vector case, follows same approach as `AssumeMatrix.selfAdjoint`.
-
+Params:
+    a = m(rows) x k(cols) matrix
+    b = k(rows) x n(cols) matrix
+Result:
+    m(rows) x n(cols)
 +/
 @safe pure nothrow @nogc
-template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
+Slice!(RCI!T, 2) mtimes(T, SliceKind kindA, SliceKind kindB)(
+    Slice!(const(T)*, 2, kindA) a,
+    Slice!(const(T)*, 2, kindB) b
+)
+    if (isFloatingPoint!T || isComplex!T)
+in
 {
-    /++
-    Params:
-        a = m(rows) x k(cols) matrix
-        b = k(rows) x n(cols) matrix
-    Result:
-        m(rows) x n(cols)
-    +/
-    Slice!(RCI!T, 2) mtimes(T, SliceKind kindA, SliceKind kindB)(
-        Slice!(const(T)*, 2, kindA) a,
-        Slice!(const(T)*, 2, kindB) b
-    )
-        if (isFloatingPoint!T || isComplex!T)
-    in
-    {
-        assert(a.length!1 == b.length!0);
-        static if (assumedMatrix == AssumedMatrix.selfAdjoint) {
-            assert(a.length!0 == a.length!1);
-            static if (isFloatingPoint!T)
-                assert(isSymmetric(a));
-        } else static if (assumedMatrix == AssumedMatrix.selfAdjointRight) {
-            assert(b.length!0 == b.length!1);
-            static if (isFloatingPoint!T)
-                assert(isSymmetric(b));
-        }
-    }
-    out (c)
-    {
-        assert(c.length!0 == a.length!0);
-        assert(c.length!1 == b.length!1);
-    }
-    do
-    {
-        // more optimisations for special cases can be added in the future
-        auto c = mininitRcslice!T(a.length!0, b.length!1);
-        static if (assumedMatrix == AssumedMatrix.general) {
-            gemm(cast(T)1, a, b, cast(T)0, c.lightScope);
-        } else static if (assumedMatrix == AssumedMatrix.selfAdjoint ||
-                          assumedMatrix == AssumedMatrix.selfAdjointRight) {
-            import cblas: Uplo, Side;
-            static if (isFloatingPoint!T) {
-                static if (assumedMatrix == AssumedMatrix.selfAdjoint) {
-                    symm(Side.Left, Uplo.Upper, cast(T)1, a, b, cast(T)0, c.lightScope);
-                } else {
-                    static if (kindA == Universal) {
-                        assert(a._stride!1 == 1 && c.universal._stride!1 == 1,
-                               "stride of `a` and output do not match, most likely the result of a transpose operation, try allocating `a` before passing it to the function, such as `a.rcslice.mtimes(b)`");
-                    }
-                    symm(Side.Right, Uplo.Upper, cast(T)1, b, a, cast(T)0, c.lightScope);
-                }
-            } else {
-                static assert(0, "Complex version not implemented");
-            }
-        } else {
-            static assert(0, "Not implemented");
-        }
-        return c;
-    }
+    assert(a.length!1 == b.length!0);
+}
+out (c)
+{
+    assert(c.length!0 == a.length!0);
+    assert(c.length!1 == b.length!1);
+}
+do
+{
+    auto c = mininitRcslice!T(a.length!0, b.length!1);
+    gemm(cast(T)1, a, b, cast(T)0, c.lightScope);
+    return c;
+}
 
-    /// ditto
-    @safe pure nothrow @nogc
-    Slice!(RCI!(Unqual!A), 2) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
-        auto ref const Slice!(RCI!A, 2, kindA) a,
-        auto ref const Slice!(RCI!B, 2, kindB) b
-    )
-        if (is(Unqual!A == Unqual!B))
-    in
-    {
-        assert(a.length!1 == b.length!0);
-    }
-    do
-    {
-        auto scopeA = a.lightScope.lightConst;
-        auto scopeB = b.lightScope.lightConst;
-        return .mtimes!assumedMatrix(scopeA, scopeB);
-    }
+/// ditto
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!A), 2) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
+    auto ref const Slice!(RCI!A, 2, kindA) a,
+    auto ref const Slice!(RCI!B, 2, kindB) b
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!1 == b.length!0);
+}
+do
+{
+    auto scopeA = a.lightScope.lightConst;
+    auto scopeB = b.lightScope.lightConst;
+    return .mtimes(scopeA, scopeB);
+}
 
-    @safe pure nothrow @nogc
-    Slice!(RCI!(Unqual!A), 2) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
-        auto ref const Slice!(RCI!A, 2, kindA) a,
-        Slice!(const(B)*, 2, kindB) b
-    )
-        if (is(Unqual!A == Unqual!B))
-    in
-    {
-        assert(a.length!1 == b.length!0);
-    }
-    do
-    {
-        auto scopeA = a.lightScope.lightConst;
-        return .mtimes!assumedMatrix(scopeA, b);
-    }
+/// ditto
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!A), 2) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
+    auto ref const Slice!(RCI!A, 2, kindA) a,
+    Slice!(const(B)*, 2, kindB) b
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!1 == b.length!0);
+}
+do
+{
+    auto scopeA = a.lightScope.lightConst;
+    return .mtimes(scopeA, b);
+}
 
-    /// ditto
-    @safe pure nothrow @nogc
-    Slice!(RCI!(Unqual!A), 2) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
-        Slice!(const(A)*, 2, kindA) a,
-        auto ref const Slice!(RCI!B, 2, kindB) b
-    )
-        if (is(Unqual!A == Unqual!B))
-    in
-    {
-        assert(a.length!1 == b.length!0);
-    }
-    do
-    {
-        auto scopeB = b.lightScope.lightConst;
-        return .mtimes!assumedMatrix(a, scopeB);
-    }
+/// ditto
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!A), 2) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
+    Slice!(const(A)*, 2, kindA) a,
+    auto ref const Slice!(RCI!B, 2, kindB) b
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!1 == b.length!0);
+}
+do
+{
+    auto scopeB = b.lightScope.lightConst;
+    return .mtimes(a, scopeB);
+}
 
-    /++
-    Params:
-        a = m(rows) x n(cols) matrix
-        b = n(rows) x 1(cols) vector
-    Result:
-        m(rows) x 1(cols)
-    +/
-    @safe pure nothrow @nogc
-    Slice!(RCI!T, 1) mtimes(T, SliceKind kindA, SliceKind kindB)(
-        Slice!(const(T)*, 2, kindA) a,
-        Slice!(const(T)*, 1, kindB) b
-    )
-        if (isFloatingPoint!T || isComplex!T)
-    in
-    {
-        assert(a.length!1 == b.length);
-        static if (assumedMatrix == AssumedMatrix.selfAdjoint ||
-                   assumedMatrix == AssumedMatrix.selfAdjointRight) {
-            assert(a.length!0 == a.length!1);
-            static if (isFloatingPoint!T)
-                assert(isSymmetric(a));
-        }
-    }
-    out (c)
-    {
-        assert(c.length == a.length);
-    }
-    do
-    {
-        auto c = mininitRcslice!T(a.length!0);
-        static if (assumedMatrix == AssumedMatrix.general) {
-            gemv(cast(T)1, a, b, cast(T)0, c.lightScope);
-        } else static if (assumedMatrix == AssumedMatrix.selfAdjoint ||
-                          assumedMatrix == AssumedMatrix.selfAdjointRight) {
-            import cblas: Uplo;
-            static if (isFloatingPoint!T)
-                symv(Uplo.Upper, cast(T)1, a, b, cast(T)0, c.lightScope);
-            else
-                static assert(0, "Complex version not implemented");
-        } else {
-            static assert(0, "Not implemented");
-        }
-        return c;
-    }
+/++
+Params:
+    a = m(rows) x n(cols) matrix
+    b = n(rows) x 1(cols) vector
+Result:
+    m(rows) x 1(cols)
++/
+@safe pure nothrow @nogc
+Slice!(RCI!T, 1) mtimes(T, SliceKind kindA, SliceKind kindB)(
+    Slice!(const(T)*, 2, kindA) a,
+    Slice!(const(T)*, 1, kindB) b
+)
+    if (isFloatingPoint!T || isComplex!T)
+in
+{
+    assert(a.length!1 == b.length);
+}
+out (c)
+{
+    assert(c.length == a.length);
+}
+do
+{
+    auto c = mininitRcslice!T(a.length!0);
+    gemv(cast(T)1, a, b, cast(T)0, c.lightScope);
+    return c;
+}
 
-    /// ditto
-    @safe pure nothrow @nogc
-    Slice!(RCI!(Unqual!A), 1) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
-        auto ref const Slice!(RCI!A, 2, kindA) a,
-        auto ref const Slice!(RCI!B, 1, kindB) b
-    )
-        if (is(Unqual!A == Unqual!B))
-    in
-    {
-        assert(a.length!1 == b.length);
-    }
-    do
-    {
-        auto scopeA = a.lightScope.lightConst;
-        auto scopeB = b.lightScope.lightConst;
-        return .mtimes!assumedMatrix(scopeA, scopeB);
-    }
+/// ditto
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!A), 1) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
+    auto ref const Slice!(RCI!A, 2, kindA) a,
+    auto ref const Slice!(RCI!B, 1, kindB) b
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!1 == b.length);
+}
+do
+{
+    auto scopeA = a.lightScope.lightConst;
+    auto scopeB = b.lightScope.lightConst;
+    return .mtimes(scopeA, scopeB);
+}
 
-    /// ditto
-    @safe pure nothrow @nogc
-    Slice!(RCI!(Unqual!A), 1) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
-        auto ref const Slice!(RCI!A, 2, kindA) a,
-        Slice!(const(B)*, 1, kindB) b
-    )
-        if (is(Unqual!A == Unqual!B))
-    in
-    {
-        assert(a.length!1 == b.length);
-    }
-    do
-    {
-        auto scopeA = a.lightScope.lightConst;
-        return .mtimes!assumedMatrix(scopeA, b);
-    }
+/// ditto
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!A), 1) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
+    auto ref const Slice!(RCI!A, 2, kindA) a,
+    Slice!(const(B)*, 1, kindB) b
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!1 == b.length);
+}
+do
+{
+    auto scopeA = a.lightScope.lightConst;
+    return .mtimes(scopeA, b);
+}
 
-    /// ditto
-    @safe pure nothrow @nogc
-    Slice!(RCI!(Unqual!A), 1) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
-        Slice!(const(A)*, 2, kindA) a,
-        auto ref const Slice!(RCI!B, 1, kindB) b
-    )
-        if (is(Unqual!A == Unqual!B))
-    in
-    {
-        assert(a.length!1 == b.length);
-    }
-    do
-    {
-        auto scopeB = b.lightScope.lightConst;
-        return .mtimes!assumedMatrix(a, scopeB);
-    }
+/// ditto
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!A), 1) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
+    Slice!(const(A)*, 2, kindA) a,
+    auto ref const Slice!(RCI!B, 1, kindB) b
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!1 == b.length);
+}
+do
+{
+    auto scopeB = b.lightScope.lightConst;
+    return .mtimes(a, scopeB);
+}
 
-    /++
-    Params:
-        b = 1(rows) x n(cols) vector
-        a = n(rows) x m(cols) matrix
-    Result:
-        1(rows) x m(cols)
-    +/
-    @safe pure nothrow @nogc
-    Slice!(RCI!T, 1) mtimes(T, SliceKind kindA, SliceKind kindB)(
-        Slice!(const(T)*, 1, kindB) b,
-        Slice!(const(T)*, 2, kindA) a
-    )
-        if (isFloatingPoint!T || isComplex!T)
-    in
-    {
-        assert(a.length!0 == b.length);
-    }
-    out (c)
-    {
-        assert(c.length == a.length!1);
-    }
-    do
-    {
-        return .mtimes!assumedMatrix(a.universal.transposed, b);
-    }
+/++
+Params:
+    b = 1(rows) x n(cols) vector
+    a = n(rows) x m(cols) matrix
+Result:
+    1(rows) x m(cols)
++/
+@safe pure nothrow @nogc
+Slice!(RCI!T, 1) mtimes(T, SliceKind kindA, SliceKind kindB)(
+    Slice!(const(T)*, 1, kindB) b,
+    Slice!(const(T)*, 2, kindA) a
+)
+    if (isFloatingPoint!T || isComplex!T)
+in
+{
+    assert(a.length!0 == b.length);
+}
+out (c)
+{
+    assert(c.length == a.length!1);
+}
+do
+{
+    return .mtimes(a.universal.transposed, b);
+}
 
-    /// ditto
-    @safe pure nothrow @nogc
-    Slice!(RCI!(Unqual!A), 1) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
-        auto ref const Slice!(RCI!B, 1, kindB) b,
-        auto ref const Slice!(RCI!A, 2, kindA) a
-    )
-        if (is(Unqual!A == Unqual!B))
-    in
-    {
-        assert(a.length!0 == b.length);
-    }
-    do
-    {
-        auto scopeA = a.lightScope.lightConst;
-        auto scopeB = b.lightScope.lightConst;
-        return .mtimes!assumedMatrix(scopeB, scopeA);
-    }
+/// ditto
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!A), 1) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
+    auto ref const Slice!(RCI!B, 1, kindB) b,
+    auto ref const Slice!(RCI!A, 2, kindA) a
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!0 == b.length);
+}
+do
+{
+    auto scopeA = a.lightScope.lightConst;
+    auto scopeB = b.lightScope.lightConst;
+    return .mtimes(scopeB, scopeA);
+}
 
-    /// ditto
-    @safe pure nothrow @nogc
-    Slice!(RCI!(Unqual!A), 1) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
-        Slice!(const(B)*, 1, kindB) b,
-        auto ref const Slice!(RCI!A, 2, kindA) a
-    )
-        if (is(Unqual!A == Unqual!B))
-    in
-    {
-        assert(a.length!0 == b.length);
-    }
-    do
-    {
-        auto scopeA = a.lightScope.lightConst;
-        return .mtimes!assumedMatrix(b, scopeA);
-    }
+/// ditto
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!A), 1) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
+    Slice!(const(B)*, 1, kindB) b,
+    auto ref const Slice!(RCI!A, 2, kindA) a
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!0 == b.length);
+}
+do
+{
+    auto scopeA = a.lightScope.lightConst;
+    return .mtimes(b, scopeA);
+}
 
-    /// ditto
-    @safe pure nothrow @nogc
-    Slice!(RCI!(Unqual!A), 1) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
-        auto ref const Slice!(RCI!B, 1, kindB) b,
-        Slice!(const(A)*, 2, kindA) a
-    )
-        if (is(Unqual!A == Unqual!B))
-    in
-    {
-        assert(a.length!0 == b.length);
-    }
-    do
-    {
-        auto scopeB = b.lightScope.lightConst;
-        return .mtimes!assumedMatrix(scopeB, a);
-    }
+/// ditto
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!A), 1) mtimes(A, B, SliceKind kindA, SliceKind kindB)(
+    auto ref const Slice!(RCI!B, 1, kindB) b,
+    Slice!(const(A)*, 2, kindA) a
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!0 == b.length);
+}
+do
+{
+    auto scopeB = b.lightScope.lightConst;
+    return .mtimes(scopeB, a);
 }
 
 /++
@@ -467,12 +396,6 @@ do
 {
     auto scopeB = b.lightScope.lightConst;
     return mtimes(a, scopeB);
-}
-
-/// ditto
-template mtimes(string assumedMatrix)
-{
-    mixin("alias mtimes = .mtimes!(AssumedMatrix." ~ assumedMatrix ~ ");");
 }
 
 /// Matrix-matrix multiplication (real)
@@ -646,63 +569,6 @@ unittest
 
     assert(x.mtimes(y) == 16);
     assert(y.mtimes(x) == 16);
-}
-
-/// Symmetric Matrix-Matrix multiplication (real)
-@safe pure nothrow @nogc
-unittest
-{
-    import mir.algorithm.iteration: equal;
-    import mir.ndslice.allocation: mininitRcslice;
-    import mir.ndslice.topology: universal;
-
-    static immutable a = [[3.0, 5, 2], [5.0, 2, 3], [2.0, 3, 1]];
-    static immutable b = [[2.0, 3], [4.0, 3], [0.0, -5]];
-    static immutable bt = [[2.0, 4, 0], [3.0, 3, -5]];
-    static immutable c = [[26.0, 14], [18.0, 6], [16.0, 10]];
-
-    auto X = mininitRcslice!double(3, 3);
-    auto Y = mininitRcslice!double(3, 2);
-    auto YT = mininitRcslice!double(2, 3);
-    auto result = mininitRcslice!double(3, 2);
-
-    X[] = a;
-    Y[] = b;
-    YT[] = bt;
-    result[] = c;
-
-    auto XY = X.mtimes!"selfAdjoint"(Y);
-    assert(XY.equal(result));
-    auto YTX = YT.mtimes!"selfAdjointRight"(X);
-    assert(YTX.equal(result.transposed));
-    // may need to allocate transposed LHS
-    auto YtransX = Y.transposed.rcslice.mtimes!"selfAdjointRight"(X);
-    assert(YtransX.equal(result.transposed));
-}
-
-/// Symmetric Matrix, specialization for MxN times Nx1
-@safe pure nothrow @nogc
-unittest
-{
-    import mir.algorithm.iteration: equal;
-    import mir.ndslice.allocation: mininitRcslice;
-
-    static immutable a = [[3.0, 5, 2], [5.0, 2, 3], [2.0, 3, 1]];
-    static immutable b = [2.0, 3, 4];
-    static immutable c = [29, 28, 17];
-
-    auto X = mininitRcslice!double(3, 3);
-    auto y = mininitRcslice!double(3);
-    auto result = mininitRcslice!double(3);
-
-    X[] = a;
-    y[] = b;
-    result[] = c;
-
-    auto Xy = X.mtimes!"selfAdjoint"(y);
-    assert(Xy.equal(result));
-    auto yXT = y.mtimes!"selfAdjoint"(X);
-    assert(yXT.equal(result));
 }
 
 /++

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -572,6 +572,360 @@ unittest
 }
 
 /++
+Symmetric matrix multiplication. Allocates result to using Mir refcounted arrays.
+
+Similar to `mtimes`, but allows for the `a` parameter to be symmetric. If 
+`is(side == Side.Left)` (the default), then the function returns the result of
+`a * b`. If `is(side == Side.Right)`, then returns the result of `b * a`. 
+
+Params:
+    side = controls whether `a` is on the left or right
+    uplo = controls whether `a` is upper symmetric or lower symmetric
++/
+template mtimesSymmetric(Side side = Side.Left, Uplo uplo = Uplo.Upper)
+{
+    /+
+    Params:
+        a = m(rows) x k(cols) matrix
+        b = k(rows) x n(cols) matrix
+    Result:
+        m(rows) x n(cols)
+    +/
+    Slice!(RCI!T, 2) mtimesSymmetric(T, SliceKind kindA, SliceKind kindB)(
+        Slice!(const(T)*, 2, kindA) a,
+        Slice!(const(T)*, 2, kindB) b
+    )
+        if (isFloatingPoint!T)
+    in
+    {
+        assert(a.length!1 == b.length!0);
+        static if (side == Side.Left)
+            assert(a.length!0 == a.length!1);
+        else
+            assert(b.length!0 == b.length!1);
+    }
+    out (c)
+    {
+        assert(c.length!0 == a.length!0);
+        assert(c.length!1 == b.length!1);
+    }
+    do
+    {
+        auto c = mininitRcslice!T(a.length!0, b.length!1);
+        static if (side == Side.Left)
+            symm(side, uplo, cast(T)1, a, b, cast(T)0, c.lightScope);
+        else
+            symm(side, uplo, cast(T)1, b, a, cast(T)0, c.lightScope);
+        return c;
+    }
+
+    /// ditto
+    @safe pure nothrow @nogc
+    Slice!(RCI!(Unqual!A), 2) mtimesSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        auto ref const Slice!(RCI!A, 2, kindA) a,
+        auto ref const Slice!(RCI!B, 2, kindB) b
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!1 == b.length!0);
+    }
+    do
+    {
+        auto scopeA = a.lightScope.lightConst;
+        auto scopeB = b.lightScope.lightConst;
+        return .mtimesSymmetric!(side, uplo)(scopeA, scopeB);
+    }
+
+    @safe pure nothrow @nogc
+    Slice!(RCI!(Unqual!A), 2) mtimesSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        auto ref const Slice!(RCI!A, 2, kindA) a,
+        Slice!(const(B)*, 2, kindB) b
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!1 == b.length!0);
+    }
+    do
+    {
+        auto scopeA = a.lightScope.lightConst;
+        return .mtimesSymmetric!(side, uplo)(scopeA, b);
+    }
+
+    /// ditto
+    @safe pure nothrow @nogc
+    Slice!(RCI!(Unqual!A), 2) mtimesSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        Slice!(const(A)*, 2, kindA) a,
+        auto ref const Slice!(RCI!B, 2, kindB) b
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!1 == b.length!0);
+    }
+    do
+    {
+        auto scopeB = b.lightScope.lightConst;
+        return .mtimesSymmetric!(side, uplo)(a, scopeB);
+    }
+}
+
+/// ditto, except `side` is inferred in matrix-vector and vector-matrix case
+template mtimesSymmetric(Uplo uplo = Uplo.Upper)
+{
+    /++
+    Params:
+        a = m(rows) x n(cols) matrix
+        b = n(rows) x 1(cols) vector
+    Result:
+        m(rows) x 1(cols)
+    +/
+    @safe pure nothrow @nogc
+    Slice!(RCI!T, 1) mtimesSymmetric(T, SliceKind kindA, SliceKind kindB)(
+        Slice!(const(T)*, 2, kindA) a,
+        Slice!(const(T)*, 1, kindB) b
+    )
+        if (isFloatingPoint!T)
+    in
+    {
+        assert(a.length!1 == b.length);
+        assert(a.length!0 == a.length!1);
+    }
+    out (c)
+    {
+        assert(c.length == a.length);
+    }
+    do
+    {
+        auto c = mininitRcslice!T(a.length!0);
+        symv(uplo, cast(T)1, a, b, cast(T)0, c.lightScope);
+        return c;
+    }
+
+    /// ditto
+    @safe pure nothrow @nogc
+    Slice!(RCI!(Unqual!A), 1) mtimesSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        auto ref const Slice!(RCI!A, 2, kindA) a,
+        auto ref const Slice!(RCI!B, 1, kindB) b
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!1 == b.length);
+    }
+    do
+    {
+        auto scopeA = a.lightScope.lightConst;
+        auto scopeB = b.lightScope.lightConst;
+        return .mtimesSymmetric!(uplo)(scopeA, scopeB);
+    }
+
+    /// ditto
+    @safe pure nothrow @nogc
+    Slice!(RCI!(Unqual!A), 1) mtimesSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        auto ref const Slice!(RCI!A, 2, kindA) a,
+        Slice!(const(B)*, 1, kindB) b
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!1 == b.length);
+    }
+    do
+    {
+        auto scopeA = a.lightScope.lightConst;
+        return .mtimesSymmetric!(uplo)(scopeA, b);
+    }
+
+    /// ditto
+    @safe pure nothrow @nogc
+    Slice!(RCI!(Unqual!A), 1) mtimesSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        Slice!(const(A)*, 2, kindA) a,
+        auto ref const Slice!(RCI!B, 1, kindB) b
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!1 == b.length);
+    }
+    do
+    {
+        auto scopeB = b.lightScope.lightConst;
+        return .mtimesSymmetric!(uplo)(a, scopeB);
+    }
+
+    /++
+    Params:
+        b = 1(rows) x n(cols) vector
+        a = n(rows) x m(cols) matrix
+    Result:
+        1(rows) x m(cols)
+    +/
+    @safe pure nothrow @nogc
+    Slice!(RCI!T, 1) mtimesSymmetric(T, SliceKind kindA, SliceKind kindB)(
+        Slice!(const(T)*, 1, kindB) b,
+        Slice!(const(T)*, 2, kindA) a
+    )
+        if (isFloatingPoint!T || isComplex!T)
+    in
+    {
+        assert(a.length!0 == b.length);
+    }
+    out (c)
+    {
+        assert(c.length == a.length!1);
+    }
+    do
+    {
+        auto c = mininitRcslice!T(b.length);
+        symv(uplo, cast(T)1, a, b, cast(T)0, c.lightScope);
+        return c;
+    }
+
+    /// ditto
+    @safe pure nothrow @nogc
+    Slice!(RCI!(Unqual!A), 1) mtimesSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        auto ref const Slice!(RCI!B, 1, kindB) b,
+        auto ref const Slice!(RCI!A, 2, kindA) a
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!0 == b.length);
+    }
+    do
+    {
+        auto scopeA = a.lightScope.lightConst;
+        auto scopeB = b.lightScope.lightConst;
+        return .mtimesSymmetric!(uplo)(scopeB, scopeA);
+    }
+
+    /// ditto
+    @safe pure nothrow @nogc
+    Slice!(RCI!(Unqual!A), 1) mtimesSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        Slice!(const(B)*, 1, kindB) b,
+        auto ref const Slice!(RCI!A, 2, kindA) a
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!0 == b.length);
+    }
+    do
+    {
+        auto scopeA = a.lightScope.lightConst;
+        return .mtimesSymmetric!(uplo)(b, scopeA);
+    }
+
+    /// ditto
+    @safe pure nothrow @nogc
+    Slice!(RCI!(Unqual!A), 1) mtimesSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        auto ref const Slice!(RCI!B, 1, kindB) b,
+        Slice!(const(A)*, 2, kindA) a
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!0 == b.length);
+    }
+    do
+    {
+        auto scopeB = b.lightScope.lightConst;
+        return .mtimesSymmetric!(uplo)(scopeB, a);
+    }
+}
+
+/// ditto
+template mtimesSymmetric(string side, string uplo = "Upper")
+{
+    mixin("alias mtimesSymmetric = .mtimesSymmetric!(Side." ~ side ~ ", Uplo." ~ uplo ~ ");");
+}
+
+/// Symmetric Matrix-Matrix multiplication
+@safe pure nothrow @nogc
+unittest
+{
+    import mir.algorithm.iteration: equal;
+    import mir.ndslice.allocation: mininitRcslice;
+    import mir.ndslice.topology: universal;
+
+    static immutable a = [[3.0, 5, 2], [5.0, 2, 3], [2.0, 3, 1]];
+    static immutable b = [[2.0, 3], [4.0, 3], [0.0, -5]];
+    static immutable bt = [[2.0, 4, 0], [3.0, 3, -5]];
+    static immutable c = [[26.0, 14], [18.0, 6], [16.0, 10]];
+
+    auto X = mininitRcslice!double(3, 3);
+    auto Y = mininitRcslice!double(3, 2);
+    auto YT = mininitRcslice!double(2, 3);
+    auto result = mininitRcslice!double(3, 2);
+
+    X[] = a;
+    Y[] = b;
+    YT[] = bt;
+    result[] = c;
+
+    auto XY = X.mtimesSymmetric(Y);
+    assert(XY.equal(result));
+
+    auto YTX = YT.mtimesSymmetric!"Right"(X);
+    assert(YTX.equal(result.transposed));
+    // may need to allocate transposed LHS
+    auto YtransX = Y.transposed.rcslice.mtimesSymmetric!"Right"(X);
+    assert(YtransX.equal(result.transposed));
+}
+
+/// Symmetric Matrix, specialization for MxN times Nx1
+@safe pure nothrow @nogc
+unittest
+{
+    import mir.algorithm.iteration: equal;
+    import mir.ndslice.allocation: mininitRcslice;
+
+    static immutable a = [[3.0, 5, 2], [5.0, 2, 3], [2.0, 3, 1]];
+    static immutable b = [2.0, 3, 4];
+    static immutable c = [29, 28, 17];
+
+    auto X = mininitRcslice!double(3, 3);
+    auto y = mininitRcslice!double(3);
+    auto result = mininitRcslice!double(3);
+
+    X[] = a;
+    y[] = b;
+    result[] = c;
+
+    auto Xy = X.mtimesSymmetric(y);
+    assert(Xy.equal(result));
+    auto yX = y.mtimesSymmetric(X);
+    assert(yX.equal(result));
+}
+
+/// Symmetric Matrix, specialization for MxN times Nx1 (GC version)
+@safe pure nothrow
+unittest
+{
+    import mir.algorithm.iteration: equal;
+    import mir.ndslice.allocation: uninitSlice;
+
+    static immutable a = [[3.0, 5, 2], [5.0, 2, 3], [2.0, 3, 1]];
+    static immutable b = [2.0, 3, 4];
+    static immutable c = [29, 28, 17];
+
+    auto X = uninitSlice!double(3, 3);
+    auto y = uninitSlice!double(3);
+    auto result = uninitSlice!double(3);
+
+    X[] = a;
+    y[] = b;
+    result[] = c;
+
+    auto Xy = X.mtimesSymmetric(y);
+    assert(Xy.equal(result));
+    auto yX = y.mtimesSymmetric(X);
+    assert(yX.equal(result));
+}
+
+/++
 Solve systems of linear equations AX = B for X.
 Computes minimum-norm solution to a linear least squares problem
 if A is not a square matrix.

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -16,6 +16,8 @@ import std.traits: isFloatingPoint, Unqual;
 import std.typecons: Flag, Yes, No;
 import mir.complex: Complex;
 
+public import mir.blas: dot;
+
 /++
 Identity matrix.
 
@@ -1602,4 +1604,102 @@ Returns:
     auto stdDev = mininitRcslice!double(2);
     assert(normalizeColumns(data, stdDev) == scaled);
     assert(stdDev == [2*sqrt(2.0), sqrt(2.0)]);
+}
+
+/++
+Additional overloads for mir-blas `dot` to handle Mir ref-counted arrays.
+
+Params:
+    a = m(rows) x 1(cols) vector
+    b = m(rows) x 1(cols) vector
+Result:
+    m(rows) x 1(cols)
+
++/
+@safe pure nothrow @nogc
+Unqual!A dot(A, B, SliceKind kindA, SliceKind kindB)(
+    auto ref const Slice!(RCI!A, 1, kindA) a,
+    auto ref const Slice!(RCI!B, 1, kindB) b
+)
+if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length == b.length);
+}
+do
+{
+    auto scopeA = a.lightScope.lightConst;
+    auto scopeB = b.lightScope.lightConst;
+    return .dot(scopeA, scopeB);
+}
+
+/// ditto
+@safe pure nothrow @nogc
+Unqual!A dot(A, B, SliceKind kindA, SliceKind kindB)(
+    auto ref const Slice!(RCI!A, 1, kindA) a,
+    Slice!(const(B)*, 1, kindB) b
+)
+if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length == b.length);
+}
+do
+{
+    auto scopeA = a.lightScope.lightConst;
+    return .dot(scopeA, b);
+}
+
+/// ditto
+@safe pure nothrow @nogc
+Unqual!A dot(A, B, SliceKind kindA, SliceKind kindB)(
+    Slice!(const(A)*, 1, kindA) a,
+    auto ref const Slice!(RCI!B, 1, kindB) b
+)
+if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length == b.length);
+}
+do
+{
+    auto scopeB = b.lightScope.lightConst;
+    return .dot(a, scopeB);
+}
+
+/// Reference-counted dot product
+@safe pure nothrow @nogc
+unittest
+{
+    import mir.ndslice.allocation: mininitRcslice;
+
+    static immutable a = [-5.0,  1,  7,  7, -4];
+    static immutable b = [ 4.0, -4, -2, 10,  4];
+
+    auto x = mininitRcslice!double(5);
+    auto y = mininitRcslice!double(5);
+
+    x[] = a;
+    y[] = b;
+
+    assert(x.dot(y) == 16);
+}
+
+/// Mix slice & RC dot product
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.allocation: mininitRcslice;
+    import mir.ndslice.slice: sliced;
+
+    static immutable a = [-5.0,  1,  7,  7, -4];
+    static immutable b = [ 4.0, -4, -2, 10,  4];
+
+    auto x = mininitRcslice!double(5);
+    auto y = b.sliced;
+
+    x[] = a;
+
+    assert(x.dot(y) == 16);
+    assert(y.dot(x) == 16);
 }

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -234,7 +234,7 @@ template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
         if (isFloatingPoint!T || isComplex!T)
     in
     {
-        assert(a.length!1 == b.length!0);
+        assert(a.length!1 == b.length);
         static if (assumedMatrix == AssumedMatrix.selfAdjoint ||
                    assumedMatrix == AssumedMatrix.selfAdjointRight) {
             assert(a.length!0 == a.length!1);
@@ -273,7 +273,7 @@ template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
         if (is(Unqual!A == Unqual!B))
     in
     {
-        assert(a.length!1 == b.length!0);
+        assert(a.length!1 == b.length);
     }
     do
     {
@@ -291,7 +291,7 @@ template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
         if (is(Unqual!A == Unqual!B))
     in
     {
-        assert(a.length!1 == b.length!0);
+        assert(a.length!1 == b.length);
     }
     do
     {
@@ -308,7 +308,7 @@ template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
         if (is(Unqual!A == Unqual!B))
     in
     {
-        assert(a.length!1 == b.length!0);
+        assert(a.length!1 == b.length);
     }
     do
     {
@@ -331,7 +331,7 @@ template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
         if (isFloatingPoint!T || isComplex!T)
     in
     {
-        assert(a.length!0 == b.length!0);
+        assert(a.length!0 == b.length);
         static if (assumedMatrix == AssumedMatrix.selfAdjoint ||
                    assumedMatrix == AssumedMatrix.selfAdjointRight) {
             assert(a.length!0 == a.length!1);
@@ -366,7 +366,7 @@ template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
         if (is(Unqual!A == Unqual!B))
     in
     {
-        assert(a.length!0 == b.length!0);
+        assert(a.length!0 == b.length);
     }
     do
     {
@@ -384,7 +384,7 @@ template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
         if (is(Unqual!A == Unqual!B))
     in
     {
-        assert(a.length!0 == b.length!0);
+        assert(a.length!0 == b.length);
     }
     do
     {
@@ -401,7 +401,7 @@ template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
         if (is(Unqual!A == Unqual!B))
     in
     {
-        assert(a.length!0 == b.length!0);
+        assert(a.length!0 == b.length);
     }
     do
     {

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -149,7 +149,7 @@ template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
         } else static if (assumedMatrix == AssumedMatrix.selfAdjoint ||
                           assumedMatrix == AssumedMatrix.selfAdjointRight) {
             import cblas: Uplo, Side;
-            static if (isFloatingPoint!T)
+            static if (isFloatingPoint!T) {
                 static if (assumedMatrix == AssumedMatrix.selfAdjoint) {
                     symm(Side.Left, Uplo.Upper, cast(T)1, a, b, cast(T)0, c.lightScope);
                 } else {
@@ -159,8 +159,9 @@ template mtimes(AssumedMatrix assumedMatrix = AssumedMatrix.general)
                     }
                     symm(Side.Right, Uplo.Upper, cast(T)1, b, a, cast(T)0, c.lightScope);
                 }
-            else
+            } else {
                 static assert(0, "Complex version not implemented");
+            }
         } else {
             static assert(0, "Not implemented");
         }


### PR DESCRIPTION
I'm open to different names for the enum that controls what to assume for the properties of the matrix. 