### PR TITLE
Add crossprod, tcrossprod, and quadraticForm functionality

### DIFF
--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -2350,7 +2350,7 @@ Slice!(RCI!(Unqual!T), 2) crossprod(T, SliceKind sliceKind)(
 out (result)
 {
     assert(result.length!0 == x.length!1, "The first dimension of the result must match the second dimension of the input");
-    assert(result.length!0 == result.length!1, "Result must be a square matrix");
+    assert(result.length!0 == result.length!1, "The result must be a square matrix");
 }
 do
 {
@@ -2367,7 +2367,6 @@ do
 Slice!(RCI!(Unqual!T), 2) crossprod(T, SliceKind sliceKind)(
     auto ref const Slice!(RCI!T, 2, sliceKind) x
 )
-do
 {
     auto scopeX = x.lightScope.lightConst;
     return .crossprod(scopeX);
@@ -2379,8 +2378,8 @@ Slice!(RCI!(Unqual!T), 2) crossprod(T, SliceKind sliceKind)(Slice!(const(T)*, 1,
     if (isFloatingPoint!T)
 out (result)
 {
-    assert(result.length!1 == x.length);
-    assert(result.length!0 == result.length!1);
+    assert(result.length!1 == x.length, "The second dimension of the result must match the length of the input");
+    assert(result.length!0 == result.length!1, "The result must be a square matrix");
 }
 do
 {
@@ -2466,8 +2465,8 @@ Slice!(RCI!(Unqual!T), 2) tcrossprod(T, SliceKind sliceKind)(
     if (isFloatingPoint!T)
 out (result)
 {
-    assert(result.length!0 == x.length!0);
-    assert(result.length!0 == result.length!1);
+    assert(result.length!0 == x.length!0, "The first dimension of the result must match the first dimension of the input");
+    assert(result.length!0 == result.length!1, "The result must be a square matrix");
 }
 do
 {
@@ -2484,7 +2483,6 @@ do
 Slice!(RCI!(Unqual!T), 2) tcrossprod(T, SliceKind sliceKind)(
     auto ref const Slice!(RCI!T, 2, sliceKind) x
 )
-do
 {
     auto scopeX = x.lightScope.lightConst;
     return .tcrossprod(scopeX);
@@ -2530,7 +2528,6 @@ unittest
 @safe pure nothrow @nogc
 unittest
 {
-    import mir.algorithm.iteration: equal;
     import mir.ndslice.allocation: mininitRcslice;
 
     static immutable a = [3.0, 5, 2, -3];
@@ -2753,6 +2750,34 @@ unittest {
     result[] = c;
 
     auto val = sigma.quadraticForm(w);
+    assert(val.equal!approxEqual(result));
+}
+
+// make sure it works with a transpose
+@safe pure nothrow @nogc
+unittest {
+    import mir.algorithm.iteration: equal;
+    import mir.math.common: approxEqual;
+    import mir.ndslice.allocation: mininitRcslice;
+    import mir.ndslice.dynamic: transposed;
+
+    static immutable a = [[0.010, 0.0030, 0.006],
+                          [0.003, 0.0225, 0.012],
+                          [0.006, 0.0120, 0.040]];
+    static immutable b = [[0.25, 0.3, 0.45],
+                          [0.30, 0.4, 0.30]];
+    static immutable c = [[0.01579, 0.01392],
+                          [0.01392, 0.01278]];
+
+    auto sigma = mininitRcslice!double(3, 3);
+    auto w = mininitRcslice!double(2, 3);
+    auto result = mininitRcslice!double(2, 2);
+
+    sigma[] = a;
+    w[] = b;
+    result[] = c;
+
+    auto val = sigma.quadraticForm(w.transposed);
     assert(val.equal!approxEqual(result));
 }
 

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -2403,7 +2403,6 @@ Slice!(RCI!(Unqual!T), 2) crossprod(T, SliceKind sliceKind)(auto ref const Slice
 @safe pure nothrow @nogc
 unittest
 {
-    import mir.algorithm.iteration: equal;
     import mir.ndslice.allocation: mininitRcslice;
 
     static immutable a = [[3.0, 5, 2, -3], [-2.0, 2, 3, 10], [0.0, 2, 1, 1]];
@@ -2416,14 +2415,13 @@ unittest
     result[] = b;
 
     auto Xcross = X.crossprod;
-    assert(Xcross.equal(result));
+    assert(Xcross == result);
 }
 
 /// crossprod (vector)
 @safe pure nothrow @nogc
 unittest
 {
-    import mir.algorithm.iteration: equal;
     import mir.ndslice.allocation: mininitRcslice;
 
     static immutable a = [3.0, 5, 2, -3];
@@ -2436,7 +2434,7 @@ unittest
     result[] = b;
 
     auto xcross = x.crossprod;
-    assert(xcross.equal(result));
+    assert(xcross == result);
 }
 
 /++
@@ -2508,7 +2506,6 @@ T tcrossprod(T, SliceKind sliceKind)(auto ref const Slice!(RCI!T, 1, sliceKind) 
 @safe pure nothrow @nogc
 unittest
 {
-    import mir.algorithm.iteration: equal;
     import mir.ndslice.allocation: mininitRcslice;
 
     static immutable a = [[3.0, 5, 2, -3], [-2.0, 2, 3, 10], [0.0, 2, 1, 1]];
@@ -2521,7 +2518,7 @@ unittest
     result[] = b;
 
     auto Xtcross = X.tcrossprod;
-    assert(Xtcross.equal(result));
+    assert(Xtcross == result);
 }
 
 /// tcrossprod (vector)

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -2816,3 +2816,349 @@ unittest {
     double val = sigma.quadraticForm(w);
     val.shouldApprox == 0.01579;
 }
+
+/++
+Given a symmetric square matrix `a` and another matrix `b`, computes the
+quadratic form `b' * a * b`.
+
+Params:
+    a = input `M x M` matrix
+    b = input `M x N` matrix
+
+Returns:
+    `N x N` matrix
+
+See_also:
+    $(WEB en.wikipedia.org/wiki/Quadratic_form, Quadratic Form)
++/
+@safe pure nothrow @nogc
+template quadraticFormSymmetric(Uplo uplo = Uplo.Upper)
+{
+    Slice!(RCI!(Unqual!T), 2) quadraticFormSymmetric(T, SliceKind kindA, SliceKind kindB)(
+        Slice!(const(T)*, 2, kindA) a,
+        Slice!(const(T)*, 2, kindB) b
+    )
+        if (isFloatingPoint!T)
+    in
+    {
+        assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the first dimension of `b`");
+        assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+    }
+    out (result)
+    {
+        assert(result.length!0 == b.length!1, "The first dimension of the result must match the second dimension of `b`");
+        assert(result.length!0 == result.length!1, "`result` must be a square matrix");
+    }
+    do
+    {
+        static if (kindB == Universal) {
+            if (b._stride!1 != 1)
+            {
+                auto result = b.transposed.mtimesSymmetric!(Side.Right, uplo)(a);
+                return result.mtimes(b);
+            }
+        }
+        auto result = a.mtimesSymmetric!(Side.Left, uplo)(b);
+        return b.transposed.mtimes(result);
+    }
+
+    /// ditto
+    Slice!(RCI!(Unqual!A), 2) quadraticFormSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        auto ref const Slice!(RCI!A, 2, kindA) a,
+        auto ref const Slice!(RCI!B, 2, kindB) b
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the first dimension of `b`");
+        assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+    }
+    do
+    {
+        auto scopeA = a.lightScope.lightConst;
+        auto scopeB = b.lightScope.lightConst;
+        return .quadraticFormSymmetric!uplo(scopeA, scopeB);
+    }
+
+    /// ditto
+    Slice!(RCI!(Unqual!A), 2) quadraticFormSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        auto ref const Slice!(RCI!A, 2, kindA) a,
+        Slice!(const(B)*, 2, kindB) b
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the first dimension of `b`");
+        assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+    }
+    do
+    {
+        auto scopeA = a.lightScope.lightConst;
+        return .quadraticFormSymmetric!uplo(scopeA, b);
+    }
+
+    /// ditto
+    @safe pure nothrow @nogc
+    Slice!(RCI!(Unqual!A), 2) quadraticFormSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        Slice!(const(A)*, 2, kindA) a,
+        auto ref const Slice!(RCI!B, 2, kindB) b
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the first dimension of `b`");
+        assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+    }
+    do
+    {
+        auto scopeB = b.lightScope.lightConst;
+        return .quadraticFormSymmetric!uplo(a, scopeB);
+    }
+
+    /// ditto
+    T quadraticFormSymmetric(T, SliceKind kindA, SliceKind kindB)(
+        Slice!(const(T)*, 2, kindA) a,
+        Slice!(const(T)*, 1, kindB) b
+    )
+        if (isFloatingPoint!T)
+    in
+    {
+        assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the length of `b`");
+        assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+    }
+    do
+    {
+        auto result = a.mtimesSymmetric!uplo(b);
+        return result.mtimes(b);
+    }
+
+    /// ditto
+    @safe pure nothrow @nogc
+    Unqual!A quadraticFormSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        auto ref const Slice!(RCI!A, 2, kindA) a,
+        auto ref const Slice!(RCI!B, 1, kindB) b
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the length of `b`");
+        assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+    }
+    do
+    {
+        auto scopeA = a.lightScope.lightConst;
+        auto scopeB = b.lightScope.lightConst;
+        return .quadraticFormSymmetric!uplo(scopeA, scopeB);
+    }
+
+    /// ditto
+    @safe pure nothrow @nogc
+    Unqual!A quadraticFormSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        auto ref const Slice!(RCI!A, 2, kindA) a,
+        Slice!(const(B)*, 1, kindB) b
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the length of `b`");
+        assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+    }
+    do
+    {
+        auto scopeA = a.lightScope.lightConst;
+        return .quadraticFormSymmetric!uplo(scopeA, b);
+    }
+
+    /// ditto
+    @safe pure nothrow @nogc
+    Unqual!A quadraticFormSymmetric(A, B, SliceKind kindA, SliceKind kindB)(
+        Slice!(const(A)*, 2, kindA) a,
+        auto ref const Slice!(RCI!B, 1, kindB) b
+    )
+        if (is(Unqual!A == Unqual!B))
+    in
+    {
+        assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the length of `b`");
+        assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+    }
+    do
+    {
+        auto scopeB = b.lightScope.lightConst;
+        return .quadraticFormSymmetric!uplo(a, scopeB);
+    }
+}
+
+/// ditto
+template quadraticFormSymmetric(string uplo)
+{
+    mixin("alias quadraticFormSymmetric = .quadraticFormSymmetric!(Uplo." ~ uplo ~ ");");
+}
+
+///
+@safe pure
+unittest {
+    import mir.algorithm.iteration: equal;
+    import mir.math.common: approxEqual;
+    import mir.ndslice.fuse: fuse;
+    import mir.ndslice.slice: sliced;
+
+    auto sigma = [[0.010, 0.0030, 0.006],
+                  [0,     0.0225, 0.012],
+                  [0,     0,      0.040]].fuse;
+    auto w = [[0.25, 0.3],
+              [0.30, 0.4],
+              [0.45, 0.3]].fuse;
+    auto result = [[0.01579, 0.01392],
+                   [0.01392, 0.01278]].fuse;
+
+    auto val = sigma.quadraticFormSymmetric(w);
+    assert(val.equal!approxEqual(result));
+}
+
+/// Ditto, but RC
+@safe pure nothrow @nogc
+unittest {
+    import mir.algorithm.iteration: equal;
+    import mir.math.common: approxEqual;
+    import mir.ndslice.allocation: mininitRcslice;
+
+    static immutable a = [[0.010, 0.0030, 0.006],
+                          [0,     0.0225, 0.012],
+                          [0,     0,      0.040]];
+    static immutable b = [[0.25, 0.3],
+                          [0.30, 0.4],
+                          [0.45, 0.3]];
+    static immutable c = [[0.01579, 0.01392],
+                          [0.01392, 0.01278]];
+
+    auto sigma = mininitRcslice!double(3, 3);
+    auto w = mininitRcslice!double(3, 2);
+    auto result = mininitRcslice!double(2, 2);
+
+    sigma[] = a;
+    w[] = b;
+    result[] = c;
+
+    auto val = sigma.quadraticFormSymmetric(w);
+    assert(val.equal!approxEqual(result));
+}
+
+// make sure it works with a transpose
+@safe pure nothrow @nogc
+unittest {
+    import mir.algorithm.iteration: equal;
+    import mir.math.common: approxEqual;
+    import mir.ndslice.allocation: mininitRcslice;
+    import mir.ndslice.dynamic: transposed;
+
+    static immutable a = [[0.010, 0.0030, 0.006],
+                          [0,     0.0225, 0.012],
+                          [0,     0,      0.040]];
+    static immutable b = [[0.25, 0.3, 0.45],
+                          [0.30, 0.4, 0.30]];
+    static immutable c = [[0.01579, 0.01392],
+                          [0.01392, 0.01278]];
+
+    auto sigma = mininitRcslice!double(3, 3);
+    auto w = mininitRcslice!double(2, 3);
+    auto result = mininitRcslice!double(2, 2);
+
+    sigma[] = a;
+    w[] = b;
+    result[] = c;
+
+    auto val = sigma.quadraticFormSymmetric(w.transposed);
+    assert(val.equal!approxEqual(result));
+}
+
+/// quadraticFormSymmetric (vector)
+@safe pure
+unittest {
+    import mir.ndslice.fuse: fuse;
+    import mir.ndslice.slice: sliced;
+    import mir.test: shouldApprox;
+
+    auto sigma = [[0.010, 0.0030, 0.006],
+                  [0,     0.0225, 0.012],
+                  [0,     0,      0.040]].fuse;
+    auto w = [0.25, 0.3, 0.45].sliced;
+    double val = sigma.quadraticFormSymmetric(w);
+    val.shouldApprox == 0.01579;
+}
+
+/// Ditto, but RC
+@safe pure nothrow @nogc
+unittest {
+    import mir.ndslice.allocation: mininitRcslice;
+    import mir.test: shouldApprox;
+
+    static immutable a = [[0.010, 0.0030, 0.006],
+                          [0,     0.0225, 0.012],
+                          [0,     0,      0.040]];
+    static immutable b = [0.25, 0.3, 0.45];
+
+    auto sigma = mininitRcslice!double(3, 3);
+    auto w = mininitRcslice!double(3);
+
+    sigma[] = a;
+    w[] = b;
+
+    double val = sigma.quadraticFormSymmetric(w);
+    val.shouldApprox == 0.01579;
+}
+
+/// Use template parameter if using lower triangular symmetric matrix
+@safe pure nothrow @nogc
+unittest {
+    import mir.algorithm.iteration: equal;
+    import mir.math.common: approxEqual;
+    import mir.ndslice.allocation: mininitRcslice;
+
+    static immutable a = [[0.0100, 0,      0],
+                          [0.0030, 0.0225, 0],
+                          [0.0060, 0.012,  0.040]];
+    static immutable b = [[0.25, 0.3],
+                          [0.30, 0.4],
+                          [0.45, 0.3]];
+    static immutable c = [[0.01579, 0.01392],
+                          [0.01392, 0.01278]];
+
+    auto sigma = mininitRcslice!double(3, 3);
+    auto w = mininitRcslice!double(3, 2);
+    auto result = mininitRcslice!double(2, 2);
+
+    sigma[] = a;
+    w[] = b;
+    result[] = c;
+
+    auto val = sigma.quadraticFormSymmetric!"Lower"(w);
+    assert(val.equal!approxEqual(result));
+}
+
+// transposed version with lower triangular symmetric matrix
+@safe pure nothrow @nogc
+unittest {
+    import mir.algorithm.iteration: equal;
+    import mir.math.common: approxEqual;
+    import mir.ndslice.allocation: mininitRcslice;
+    import mir.ndslice.dynamic: transposed;
+
+    static immutable a = [[0.0100, 0,      0],
+                          [0.0030, 0.0225, 0],
+                          [0.0060, 0.012,  0.040]];
+    static immutable b = [[0.25, 0.3, 0.45],
+                          [0.30, 0.4, 0.30]];
+    static immutable c = [[0.01579, 0.01392],
+                          [0.01392, 0.01278]];
+
+    auto sigma = mininitRcslice!double(3, 3);
+    auto w = mininitRcslice!double(2, 3);
+    auto result = mininitRcslice!double(2, 2);
+
+    sigma[] = a;
+    w[] = b;
+    result[] = c;
+
+    auto val = sigma.quadraticFormSymmetric!"Lower"(w.transposed);
+    assert(val.equal!approxEqual(result));
+}

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -2707,39 +2707,35 @@ do
 ///
 @safe pure
 unittest {
-    import mir.algorithm.iteration: equal;
-    import mir.math.common: approxEqual;
     import mir.ndslice.fuse: fuse;
     import mir.ndslice.slice: sliced;
 
-    auto sigma = [[0.010, 0.0030, 0.006],
-                  [0.003, 0.0225, 0.012],
-                  [0.006, 0.0120, 0.040]].fuse;
-    auto w = [[0.25, 0.3],
-              [0.30, 0.4],
-              [0.45, 0.3]].fuse;
-    auto result = [[0.01579, 0.01392],
-                   [0.01392, 0.01278]].fuse;
+    auto sigma = [[1.0,  2, 3],
+                  [10.0, 9, 8],
+                  [5.0,  6, 7]].fuse;
+    auto w = [[1.0, 2],
+              [2.0, 6],
+              [4.0, 1]].fuse;
+    auto result = [[317.0, 393],
+                   [439.0, 579]].fuse;
 
     auto val = sigma.quadraticForm(w);
-    assert(val.equal!approxEqual(result));
+    assert(val == result);
 }
 
 /// Ditto, but RC
 @safe pure nothrow @nogc
 unittest {
-    import mir.algorithm.iteration: equal;
-    import mir.math.common: approxEqual;
     import mir.ndslice.allocation: mininitRcslice;
 
-    static immutable a = [[0.010, 0.0030, 0.006],
-                          [0.003, 0.0225, 0.012],
-                          [0.006, 0.0120, 0.040]];
-    static immutable b = [[0.25, 0.3],
-                          [0.30, 0.4],
-                          [0.45, 0.3]];
-    static immutable c = [[0.01579, 0.01392],
-                          [0.01392, 0.01278]];
+    static immutable a = [[1.0,  2, 3],
+                          [10.0, 9, 8],
+                          [5.0,  6, 7]];
+    static immutable b = [[1.0, 2],
+                          [2.0, 6],
+                          [4.0, 1]];
+    static immutable c = [[317.0, 393],
+                          [439.0, 579]];
 
     auto sigma = mininitRcslice!double(3, 3);
     auto w = mininitRcslice!double(3, 2);
@@ -2750,24 +2746,22 @@ unittest {
     result[] = c;
 
     auto val = sigma.quadraticForm(w);
-    assert(val.equal!approxEqual(result));
+    assert(val == result);
 }
 
 // make sure it works with a transpose
 @safe pure nothrow @nogc
 unittest {
-    import mir.algorithm.iteration: equal;
-    import mir.math.common: approxEqual;
     import mir.ndslice.allocation: mininitRcslice;
     import mir.ndslice.dynamic: transposed;
 
-    static immutable a = [[0.010, 0.0030, 0.006],
-                          [0.003, 0.0225, 0.012],
-                          [0.006, 0.0120, 0.040]];
-    static immutable b = [[0.25, 0.3, 0.45],
-                          [0.30, 0.4, 0.30]];
-    static immutable c = [[0.01579, 0.01392],
-                          [0.01392, 0.01278]];
+    static immutable a = [[1.0,  2, 3],
+                          [10.0, 9, 8],
+                          [5.0,  6, 7]];
+    static immutable b = [[1.0, 2, 4],
+                          [2.0, 6, 1]];
+    static immutable c = [[317.0, 393],
+                          [439.0, 579]];
 
     auto sigma = mininitRcslice!double(3, 3);
     auto w = mininitRcslice!double(2, 3);
@@ -2778,7 +2772,7 @@ unittest {
     result[] = c;
 
     auto val = sigma.quadraticForm(w.transposed);
-    assert(val.equal!approxEqual(result));
+    assert(val == result);
 }
 
 /// quadraticForm (vector)
@@ -2786,26 +2780,26 @@ unittest {
 unittest {
     import mir.ndslice.fuse: fuse;
     import mir.ndslice.slice: sliced;
-    import mir.test: shouldApprox;
+    import mir.test: should;
 
-    auto sigma = [[0.010, 0.0030, 0.006],
-                  [0.003, 0.0225, 0.012],
-                  [0.006, 0.0120, 0.040]].fuse;
-    auto w = [0.25, 0.3, 0.45].sliced;
+    auto sigma = [[1.0,  2, 3],
+                  [10.0, 9, 8],
+                  [5.0,  6, 7]].fuse;
+    auto w = [1.0, 2, 4].sliced;
     double val = sigma.quadraticForm(w);
-    val.shouldApprox == 0.01579;
+    val.should == 317;
 }
 
 /// Ditto, but RC
 @safe pure nothrow @nogc
 unittest {
     import mir.ndslice.allocation: mininitRcslice;
-    import mir.test: shouldApprox;
+    import mir.test: should;
 
-    static immutable a = [[0.010, 0.0030, 0.006],
-                          [0.003, 0.0225, 0.012],
-                          [0.006, 0.0120, 0.040]];
-    static immutable b = [0.25, 0.3, 0.45];
+    static immutable a = [[1.0,  2, 3],
+                          [10.0, 9, 8],
+                          [5.0,  6, 7]];
+    static immutable b = [1.0, 2, 4];
 
     auto sigma = mininitRcslice!double(3, 3);
     auto w = mininitRcslice!double(3);
@@ -2814,7 +2808,7 @@ unittest {
     w[] = b;
 
     double val = sigma.quadraticForm(w);
-    val.shouldApprox == 0.01579;
+    val.should == 317;
 }
 
 /++

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -2542,3 +2542,252 @@ unittest
     auto xtcross = x.tcrossprod;
     assert(xtcross == 47);
 }
+
+/++
+Given a square matrix `a` and another matrix `b`, computes the quadratic form
+`b' * a * b`.
+
+Params:
+    a = input `M x M` matrix
+    b = input `M x N` matrix
+
+Returns:
+    `N x N` matrix
+
+See_also:
+    $(WEB en.wikipedia.org/wiki/Quadratic_form, Quadratic Form)
++/
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!T), 2) quadraticForm(T, SliceKind kindA, SliceKind kindB)(
+    Slice!(const(T)*, 2, kindA) a,
+    Slice!(const(T)*, 2, kindB) b
+)
+    if (isFloatingPoint!T)
+in
+{
+    assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the first dimension of `b`");
+    assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+}
+out (result)
+{
+    assert(result.length!0 == b.length!1, "The first dimension of the result must match the second dimension of `b`");
+    assert(result.length!0 == result.length!1, "`result` must be a square matrix");
+}
+do
+{
+    auto result = a.mtimes(b);
+    return b.transposed.mtimes(result);
+}
+
+/// ditto
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!A), 2) quadraticForm(A, B, SliceKind kindA, SliceKind kindB)(
+    auto ref const Slice!(RCI!A, 2, kindA) a,
+    auto ref const Slice!(RCI!B, 2, kindB) b
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the first dimension of `b`");
+    assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+}
+do
+{
+    auto scopeA = a.lightScope.lightConst;
+    auto scopeB = b.lightScope.lightConst;
+    return .quadraticForm(scopeA, scopeB);
+}
+
+/// ditto
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!A), 2) quadraticForm(A, B, SliceKind kindA, SliceKind kindB)(
+    auto ref const Slice!(RCI!A, 2, kindA) a,
+    Slice!(const(B)*, 2, kindB) b
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the first dimension of `b`");
+    assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+}
+do
+{
+    auto scopeA = a.lightScope.lightConst;
+    return .quadraticForm(scopeA, b);
+}
+
+/// ditto
+@safe pure nothrow @nogc
+Slice!(RCI!(Unqual!A), 2) quadraticForm(A, B, SliceKind kindA, SliceKind kindB)(
+    Slice!(const(A)*, 2, kindA) a,
+    auto ref const Slice!(RCI!B, 2, kindB) b
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the first dimension of `b`");
+    assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+}
+do
+{
+    auto scopeB = b.lightScope.lightConst;
+    return .quadraticForm(a, scopeB);
+}
+
+/// ditto
+@safe pure nothrow @nogc
+T quadraticForm(T, SliceKind kindA, SliceKind kindB)(
+    Slice!(const(T)*, 2, kindA) a,
+    Slice!(const(T)*, 1, kindB) b
+)
+    if (isFloatingPoint!T)
+in
+{
+    assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the length of `b`");
+    assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+}
+do
+{
+    auto result = a.mtimes(b);
+    return result.mtimes(b);
+}
+
+/// ditto
+@safe pure nothrow @nogc
+Unqual!A quadraticForm(A, B, SliceKind kindA, SliceKind kindB)(
+    auto ref const Slice!(RCI!A, 2, kindA) a,
+    auto ref const Slice!(RCI!B, 1, kindB) b
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the length of `b`");
+    assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+}
+do
+{
+    auto scopeA = a.lightScope.lightConst;
+    auto scopeB = b.lightScope.lightConst;
+    return .quadraticForm(scopeA, scopeB);
+}
+
+/// ditto
+@safe pure nothrow @nogc
+Unqual!A quadraticForm(A, B, SliceKind kindA, SliceKind kindB)(
+    auto ref const Slice!(RCI!A, 2, kindA) a,
+    Slice!(const(B)*, 1, kindB) b
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the length of `b`");
+    assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+}
+do
+{
+    auto scopeA = a.lightScope.lightConst;
+    return .quadraticForm(scopeA, b);
+}
+
+/// ditto
+@safe pure nothrow @nogc
+Unqual!A quadraticForm(A, B, SliceKind kindA, SliceKind kindB)(
+    Slice!(const(A)*, 2, kindA) a,
+    auto ref const Slice!(RCI!B, 1, kindB) b
+)
+    if (is(Unqual!A == Unqual!B))
+in
+{
+    assert(a.length!1 == b.length!0, "The second dimension of `a` must be equal to the length of `b`");
+    assert(a.length!0 == a.length!1, "`a` must be a square matrix");
+}
+do
+{
+    auto scopeB = b.lightScope.lightConst;
+    return .quadraticForm(a, scopeB);
+}
+
+///
+@safe pure
+unittest {
+    import mir.algorithm.iteration: equal;
+    import mir.math.common: approxEqual;
+    import mir.ndslice.fuse: fuse;
+    import mir.ndslice.slice: sliced;
+
+    auto sigma = [[0.010, 0.0030, 0.006],
+                  [0.003, 0.0225, 0.012],
+                  [0.006, 0.0120, 0.040]].fuse;
+    auto w = [[0.25, 0.3],
+              [0.30, 0.4],
+              [0.45, 0.3]].fuse;
+    auto result = [[0.01579, 0.01392],
+                   [0.01392, 0.01278]].fuse;
+
+    auto val = sigma.quadraticForm(w);
+    assert(val.equal!approxEqual(result));
+}
+
+/// Ditto, but RC
+@safe pure nothrow @nogc
+unittest {
+    import mir.algorithm.iteration: equal;
+    import mir.math.common: approxEqual;
+    import mir.ndslice.allocation: mininitRcslice;
+
+    static immutable a = [[0.010, 0.0030, 0.006],
+                          [0.003, 0.0225, 0.012],
+                          [0.006, 0.0120, 0.040]];
+    static immutable b = [[0.25, 0.3],
+                          [0.30, 0.4],
+                          [0.45, 0.3]];
+    static immutable c = [[0.01579, 0.01392],
+                          [0.01392, 0.01278]];
+
+    auto sigma = mininitRcslice!double(3, 3);
+    auto w = mininitRcslice!double(3, 2);
+    auto result = mininitRcslice!double(2, 2);
+
+    sigma[] = a;
+    w[] = b;
+    result[] = c;
+
+    auto val = sigma.quadraticForm(w);
+    assert(val.equal!approxEqual(result));
+}
+
+/// quadraticForm (vector)
+@safe pure
+unittest {
+    import mir.ndslice.fuse: fuse;
+    import mir.ndslice.slice: sliced;
+    import mir.test: shouldApprox;
+
+    auto sigma = [[0.010, 0.0030, 0.006],
+                  [0.003, 0.0225, 0.012],
+                  [0.006, 0.0120, 0.040]].fuse;
+    auto w = [0.25, 0.3, 0.45].sliced;
+    double val = sigma.quadraticForm(w);
+    val.shouldApprox == 0.01579;
+}
+
+/// Ditto, but RC
+@safe pure nothrow @nogc
+unittest {
+    import mir.ndslice.allocation: mininitRcslice;
+    import mir.test: shouldApprox;
+
+    static immutable a = [[0.010, 0.0030, 0.006],
+                          [0.003, 0.0225, 0.012],
+                          [0.006, 0.0120, 0.040]];
+    static immutable b = [0.25, 0.3, 0.45];
+
+    auto sigma = mininitRcslice!double(3, 3);
+    auto w = mininitRcslice!double(3);
+
+    sigma[] = a;
+    w[] = b;
+
+    double val = sigma.quadraticForm(w);
+    val.shouldApprox == 0.01579;
+}

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -598,11 +598,11 @@ template mtimesSymmetric(Side side = Side.Left, Uplo uplo = Uplo.Upper)
         if (isFloatingPoint!T)
     in
     {
-        assert(a.length!1 == b.length!0);
+        assert(a.length!1 == b.length!0, "The second dimension of `a` must match the first dimension of `b`");
         static if (side == Side.Left)
-            assert(a.length!0 == a.length!1);
+            assert(a.length!0 == a.length!1, "With `Side.Left`, `a` assumed to be a square matrix");
         else
-            assert(b.length!0 == b.length!1);
+            assert(b.length!0 == b.length!1, "With `Side.Right`, `b` assumed to be a square matrix");
     }
     out (c)
     {
@@ -847,7 +847,7 @@ template mtimesSymmetric(string side, string uplo = "Upper")
 unittest
 {
     import mir.algorithm.iteration: equal;
-    import mir.ndslice.allocation: mininitRcslice;
+    import mir.ndslice.allocation: mininitRcslice, rcslice;
 
     static immutable a = [[3.0, 5, 2], [5.0, 2, 3], [2.0, 3, 1]];
     static immutable b = [[2.0, 3], [4.0, 3], [0.0, -5]];


### PR DESCRIPTION
This adds some additional functionality for matrix multiplication.

First, it adds `crossprod` and `tcrossprod`, which are very similar to R's versions of these functions (https://stat.ethz.ch/R-manual/R-devel/library/base/html/crossprod.html). While there are some cases where this mimics the behavior of `mtimes`, the main reason to use them is because they have specializations for BLAS functions where they are appropriate. Where I include calls to `mtimes` it is mainly so that the functions can be used somewhat seamlessly (Note: I left off versions of these functions where the calls are mixed, so for instance, `crossprod(a, b)` where `a` is one-dimensional and `b` is two-dimensional, use `mtimes` in that case). 

Second, it adds `quadraticForm` and `quadraticFormSymmetric`, which implement the call to `a' * b * a` where `b` is a general matrix or a symmetric matrix, respectively. This calculation can show up all over the place and can be useful to make it into a function to avoid repeating oneself. I implemented these functions somewhat naively with calls to `mtimes` and `mtimesSymmetric` without an attempt to avoid allocations. 