### PR TITLE
add pinv to lubeck2 and make svd nothrow

### DIFF
--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -2136,18 +2136,20 @@ Slice!(RCI!T, 2) pinv
 @safe pure
 unittest
 {
-    import std.math : isClose;
-    auto A = iota(15).as!double.sliced(3,5);
+    import mir.algorithm.iteration: equal;
+    import mir.math.common: approxEqual;
+    import mir.ndslice.slice: sliced;
+    import mir.ndslice.topology: iota, as;
+
+    auto A = iota([15], 1).as!double.sliced(3,5);
 
     auto A_pinv = pinv(A);
 
     auto A1 = mtimes(A, mtimes(A_pinv, A));
     auto A2 = mtimes(A_pinv, mtimes(A, A_pinv));
 
-    auto boolMat = zip(A1, A2).filter!(pair => pair.a.isClose(pair.b));
-    boolMat.all!(aa => aa == true);
-
-    assert(boolMat.all!(aa => aa == true), "Pseudo-inverse property failed");
+    assert(A.equal!approxEqual(A1));
+    assert(A_pinv.equal!approxEqual(A2));
 }
 ///complex extensions
 

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -1240,7 +1240,7 @@ Returns: error code from CBlas
         enforce!("svd: " ~ msg)(!info);
     }
 
-    return SvdResult!T(svdresult.vt, svdresult.s, svdresult.u); //transposed
+    return svdresult; //transposed
 }
 
 @safe pure @nogc nothrow SvdResult!T svdImpl

--- a/source/kaleidic/lubeck2.d
+++ b/source/kaleidic/lubeck2.d
@@ -2096,7 +2096,7 @@ Slice!(RCI!T, 2)
 
     if(lowApiExecuted)
     {
-        enum msg = (algorithm == "gesvd" ? "pinv: svd: DBDSDC did not converge, updating process failed" : "pinv: svd: DBDSQR did not converge");
+        enum msg ="pinv: pinv was not successful due to a convergence issue during SVD calculation.";
         assert(!info,  msg);
     }
 


### PR DESCRIPTION
pinv is added to lubeck2. for potential code reviewers, please confirm this:

instead of just enforce!("svd: " ~ msg)(!info);

I had to use the below version to make the function nothrow. I am using this method in DCV a lot. It might be a problem for release builds due to assert, but at least it is nothrow, and works with debug builds.

try enforce!("svd: " ~ msg)(!info);
catch(Exception e) assert(false, e.msg);